### PR TITLE
fix(ComponentAttr): 修复属性配置面板因props传递错误导致的渲染崩溃

### DIFF
--- a/src/editor/components/Setting/ComponentAttr/FormElementRenderer.tsx
+++ b/src/editor/components/Setting/ComponentAttr/FormElementRenderer.tsx
@@ -40,19 +40,13 @@ export function FormElementRenderer({
 }: FormElementRendererProps) {
   // 将 setting (静态配置) 与 restProps (动态注入的 props) 分离开
 
-  // 从静态配置中提取渲染所需的信息
   const {
     type,
     options,
     component: componentName,
-    props: customSetterProps, // 这是 meta.tsx 中为 custom setter 定义的 props
-  } = setting;
-
-  // 从静态配置中提取应直接传递给 antd 控件的额外 props
-  const {
+    props: customSetterProps,
     name: _omitName,
     label: _omitLabel,
-    type: _omitType,
     ...controlProps
   } = setting;
 
@@ -96,7 +90,6 @@ export function FormElementRenderer({
     case "custom": {
       const CustomComponent = customSetters[componentName as string];
       if (CustomComponent) {
-        // ✔️ 修正：将 restProps (value, onChange) 和 customSetterProps (静态配置) 合并传递
         return <CustomComponent {...restProps} {...customSetterProps} />;
       }
       return <Input {...controlProps} {...restProps} allowClear />;

--- a/src/editor/materials/General/Button/meta.tsx
+++ b/src/editor/materials/General/Button/meta.tsx
@@ -39,7 +39,7 @@ export default {
       type: "select",
       options: ["_self", "_blank", "_parent", "_top"],
     },
-    { name: "children", label: "文本", type: "input" },
+    { name: "text", label: "文本", type: "input" },
   ],
   styleSetter: [
     // {

--- a/src/editor/utils/formUtils.ts
+++ b/src/editor/utils/formUtils.ts
@@ -8,6 +8,7 @@
 export function normalizeOptions(
   options?: any[]
 ): Array<{ label: any; value: any }> {
+  if (!Array.isArray(options)) return [];
   if (!options) return [];
   if (options.length > 0 && typeof options[0] === "string") {
     return (options as string[]).map((v) => ({ label: v, value: v }));


### PR DESCRIPTION
在重构FormElementRenderer组件后，未能正确处理setter配置中的options属性。这导致该属性以错误的格式（例如，字符串数组）被直接透传给了Ant Design的Select等需要对象数组的组件，从而覆盖了经过normalizeOptions函数正确处理后的options，引发了组件内部的类型错误并导致渲染崩溃。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Button properties panel now binds the text field correctly to “text,” aligning with default values and preventing confusion.
  - Improved stability for option-based inputs by safely handling non-array option sources, reducing potential errors in forms.
- Refactor
  - Streamlined internal form rendering logic to remove redundant prop handling and comments, with no impact on behavior or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->