### PR TITLE
feat(renderer): implement unified SchemaRenderer core

### DIFF
--- a/REFACTOR_PLAN.md
+++ b/REFACTOR_PLAN.md
@@ -2,13 +2,14 @@
 
 > **版本核心**: 本文档包含了具体的代码级执行步骤、目标目录结构和接口定义。
 
-## 总览：四个 Branch 的依赖关系
+## 总览：五个 Branch 的依赖关系
 
 ```
-refactor/monorepo-foundation (Branch 1)
-    └── refactor/iframe-preview (Branch 2)  ← 依赖 Branch 1 拆出的 renderer 包
-        └── refactor/codegen-decoupling (Branch 3)  ← 依赖 Branch 1 的 monorepo 结构
-            └── refactor/collab-crdt (Branch 4)  ← 依赖 Branch 1 的 schema 包
+refactor/monorepo-foundation (Branch 1)           ← ✅ 已完成
+    ├── refactor/renderer-unification (Branch 1.5) ← 🆕 激活 @lowcode/renderer，统一渲染引擎
+    │   └── refactor/iframe-preview (Branch 2)     ← 预览模式也走 iframe 隔离
+    ├── refactor/codegen-decoupling (Branch 3)     ← 依赖 Branch 1 的 monorepo 结构
+    └── refactor/collab-crdt (Branch 4)            ← 依赖 Branch 1 的 schema 包
 ```
 
 ---
@@ -127,78 +128,175 @@ lowcode-editor/
 
 ---
 
-## Branch 2: `refactor/iframe-preview`
+## Branch 1.5: `refactor/renderer-unification` 🆕
+
+> **参考**: 阿里巴巴 lowcode-engine 的分层思路（渲染核心统一、设计态能力通过注入点扩展）
+
+### 背景：当前问题
+
+当前 `@lowcode/renderer` 包尚未被业务路径消费，编辑态与预览态分别维护了两套递归渲染逻辑。
+
+| 场景         | 实现位置                                                       | 渲染方式                                     |
+| ------------ | -------------------------------------------------------------- | -------------------------------------------- |
+| 编辑模式画布 | `packages/editor/src/renderer/components/RendererEditArea.tsx` | iframe 内渲染，通过 postMessage 与 Host 通信 |
+| 预览模式     | `packages/editor/src/editor/components/Preview/index.tsx`      | Host 窗口直接渲染，无样式隔离                |
 
 ### 目标
 
-用 **iframe 沙箱** 替换当前的同页面预览，实现彻底的样式和环境隔离。
+将 `@lowcode/renderer` 变成唯一渲染核心，遵循 lowcode-engine 的关键原则：
 
-### 前置依赖
+1. **同一渲染核心服务 design/live 两种模式**（不是两套 renderer）
+2. **设计态能力通过注入点扩展**（如 `customCreateElement` / `onCompGetRef`）
+3. **编辑器专有能力不下沉到 renderer 包**（拖拽、蒙层、事件编排由 editor 维护）
 
-Branch 1 完成（`@lowcode/renderer` 包已抽离）。
+### 最终架构（贴合当前项目）
+
+```
+@lowcode/renderer
+  ├─ SchemaRenderer（纯渲染核心）
+  ├─ types（RendererProps / DesignHooks / RenderContext）
+  └─ utils（可选：props 解析、condition/loop 等）
+
+@lowcode/editor
+  ├─ renderer/RendererEditArea  → SchemaRenderer(design)
+  │                              + DragWrapper + HoverMask + SelectedMask
+  └─ editor/components/Preview  → SchemaRenderer(live)
+                                 + EventOrchestrator（仍在 editor 包）
+```
 
 ### 详细步骤
 
-**Step 2.1：创建 Renderer Host 页面**
+**Step 1.5.0：冻结渲染输入契约（先做）**
 
-- 在 `packages/renderer/` 中新增一个独立的 HTML 入口：`packages/renderer/src/host.tsx`。
-- 这是一个极简的 React 应用，功能是：
-  1. 监听 `window.addEventListener('message', ...)` 接收来自父窗口的 Schema 数据。
-  2. 用 `<Renderer>` 组件渲染收到的 Schema。
-  3. 将用户交互事件通过 `parent.postMessage(...)` 回传给编辑器。
-- Vite 配置为独立打包，产物是一个可独立加载的 HTML 页面。
-
-**Step 2.2：设计 PostMessage 通信协议**
+统一输入模型为：`components + rootId + componentMap`（范式化 Map），不再混用树结构输入。
 
 ```typescript
-// packages/schema/src/iframe-protocol.ts
-
-/** 编辑器 → iframe */
-export type EditorToRendererMessage =
-  | { type: "RENDER"; payload: { schema: ISchemaNode[]; components: string[] } }
-  | { type: "UPDATE_PROPS"; payload: { componentId: number; props: any } }
-  | { type: "SELECT"; payload: { componentId: number | null } }
-  | { type: "HOVER"; payload: { componentId: number | null } };
-
-/** iframe → 编辑器 */
-export type RendererToEditorMessage =
-  | { type: "COMPONENT_CLICK"; payload: { componentId: number } }
-  | { type: "COMPONENT_HOVER"; payload: { componentId: number } }
-  | {
-      type: "EVENT_FIRED";
-      payload: { componentId: number; eventName: string; args: unknown[] };
-    }
-  | { type: "RENDERER_READY" }
-  | { type: "DOM_RECT"; payload: { componentId: number; rect: DOMRect } };
+export interface SchemaRendererProps {
+  components: Record<number, Component>;
+  rootId: number;
+  componentMap: Record<string, ComponentConfig>;
+  designMode?: "design" | "live";
+  designHooks?: {
+    onCompGetRef?: (id: number, el: HTMLElement | null) => void;
+    customCreateElement?: (
+      componentId: number,
+      componentName: string,
+      element: React.ReactElement,
+    ) => React.ReactElement;
+  };
+  onEvent?: (componentId: number, eventName: string, args: unknown[]) => void;
+}
 ```
 
-**Step 2.3：改造 EditArea 画布区**
+**Step 1.5.1：实现 SchemaRenderer 核心（renderer 包）**
 
-- 当前 `EditArea` 中直接渲染组件的逻辑，替换为嵌入一个 `<iframe>`。
-- 创建 `useIframeBridge` Hook：
-  - 负责向 iframe 发送 Schema 更新。
-  - 负责接收 iframe 中的点击/悬停事件，同步到 `uiStore.setCurComponentId`。
-  - 当 store 中 `components` 发生变化时，自动 `postMessage` 新的 Schema 给 iframe。
-- 选中遮罩 (SelectedMask) 改为基于 iframe 内回传的 `DOMRect` 定位，叠加在 iframe 之上（使用 `pointer-events: none` 的绝对定位层）。
+- 只实现纯渲染能力：组件查找、props 合并、children 递归、Suspense 包裹
+- `designMode="live"` 时优先 `runtimeComponent`
+- `designMode="design"` 时支持注入 `data-component-id` 与 ref 收集
 
-**Step 2.4：拖拽适配**
+**Step 1.5.2：明确能力边界（对齐阿里分层）**
 
-- 当前使用的 `@dnd-kit` 拖拽需要适配跨 iframe 场景。
-- 方案 A（推荐）：拖拽操作在 **编辑器侧** 完成，iframe 只负责渲染。拖拽指示器（drop indicator）覆盖在 iframe 上方。
-- 方案 B：使用 `drag-and-drop-iframe-events` 库桥接 iframe 内外的拖拽事件。
+保留在 `@lowcode/editor`：
+
+- 拖拽排序（`RendererDraggableNode`）
+- Hover/Selected 蒙层
+- 事件编排（`goToLink` / `showMessage` / `customJs` / `componentMethod`）
+
+保留在 `@lowcode/renderer`：
+
+- 纯渲染管道与模式切换
+- 设计态注入点（hook/回调），不依赖 store
+
+**Step 1.5.3：替换编辑态渲染路径**
+
+将 `RendererEditArea.RenderNode` 替换为 `SchemaRenderer(design)`；通过 `customCreateElement` 注入 DragWrapper；保留现有鼠标捕获与 postMessage 交互链路。
+
+**Step 1.5.4：替换预览态渲染路径**
+
+将 `Preview.RenderNode` 替换为 `SchemaRenderer(live)`；`EventOrchestrator` 迁到 editor 内独立模块（不放 renderer 包）。
+
+**Step 1.5.5：兼容层与灰度开关**
+
+新增特性开关（例如 `renderer.unified=true/false`），允许旧渲染路径与新路径并存 1 个迭代，支持快速回滚。
+
+**Step 1.5.6：验证**
+
+- [ ] `pnpm build` 全包通过
+- [ ] 编辑态拖拽、选中、悬停行为不回归
+- [ ] 预览态事件编排与旧版一致
+- [ ] 关键链路仍有 `data-component-id`，蒙层定位正常
+- [ ] `@lowcode/renderer` 无 editor/store 依赖
+
+### 预估
+
+- **工期**: 3-4 天
+- **风险**: 中（替换两条渲染路径）
+- **收益**: 去重、后续功能扩展成本显著下降
+
+---
+
+## Branch 2: `refactor/iframe-preview` (更新)
+
+### 目标
+
+将预览模式迁入 iframe，形成编辑/预览统一隔离环境，提升所见即所得一致性。
+
+### 前置依赖
+
+Branch 1.5 完成（统一渲染核心已落地并灰度验证）。
+
+### 设计取舍（参考阿里方案）
+
+- 阿里在同域下可用共享引用通信（`window.LCSimulatorHost`）提升效率
+- 当前项目已稳定使用 postMessage，且边界更清晰
+- **本阶段保持 postMessage，不切通信机制**，优先完成预览 iframe 化
+
+### 详细步骤
+
+**Step 2.1：统一 iframe 入口，支持 edit/preview 双模式**
+
+`RendererApp` 根据 `mode` 渲染 `RendererEditArea` 或 `RendererPreviewArea`，两者都复用 `SchemaRenderer`。
+
+**Step 2.2：新增 RendererPreviewArea（iframe 内）**
+
+- 使用 `SchemaRenderer(designMode="live")`
+- 复用 editor 侧 EventOrchestrator（通过消息或上下文注入）
+- 不引入第二套渲染实现
+
+**Step 2.3：协议策略（先复用、后扩展）**
+
+优先复用现有 `SYNC_UI_STATE` 的 `mode` 同步能力。
+
+仅当需要“瞬时命令语义”时，再新增 `SWITCH_MODE`，避免协议膨胀。
+
+**Step 2.4：两阶段退役旧 Preview**
+
+1. 阶段 A（灰度）：保留旧 Preview，使用开关 `preview.useIframe`
+2. 阶段 B（收口）：灰度稳定后删除旧 Preview 组件与旧入口分支
 
 **Step 2.5：响应式预览**
 
-- 利用 iframe 天然支持尺寸控制的特性，移除当前 `canvasSize` 对 div 宽度的 hack。
-- 直接设置 `<iframe width={canvasSize.width} height={canvasSize.height}>` 即可实现手机/平板/桌面预览。
+继续使用 `canvasSize` 驱动 iframe 尺寸，统一编辑/预览设备视图能力。
 
-**Step 2.6：验证**
+**Step 2.6：迁移安全与回滚策略**
 
-- 编辑器画布中组件渲染正常，样式无污染。
-- 点击组件能正确选中（SelectedMask 定位准确）。
-- 拖拽组件到画布功能正常。
-- 手机/平板尺寸切换功能正常。
-- 自定义 JS 事件在 iframe 沙箱中安全执行（复用现有 `sandboxExecutor`）。
+- 增加监控指标：模式切换耗时、消息失败率、渲染异常率
+- 保留快速回滚：`preview.useIframe=false` 立即回退旧链路
+- 明确兼容窗口：至少 1 个小版本并行保留
+
+**Step 2.7：验证**
+
+- [ ] 编辑模式功能不受影响
+- [ ] 预览模式在 iframe 内正确渲染且无样式污染
+- [ ] edit/preview 切换稳定，无明显卡顿
+- [ ] 事件编排与旧 Preview 行为一致
+- [ ] 连续切换与长时会话无明显内存泄漏
+
+### 预估
+
+- **工期**: 3-4 天
+- **风险**: 中高（跨 iframe 事件与模式切换）
+- **收益**: 一致性提升、架构收敛、维护成本下降
 
 ---
 
@@ -383,7 +481,8 @@ export function componentsToYjs(
 
 ## 执行建议
 
-1. **Monorepo Foundation**: 3-5 天 (⭐⭐ 中)
-2. **Iframe Preview**: 5-7 天 (⭐⭐⭐ 高)
-3. **CodeGen Decoupling**: 2-3 天 (⭐ 低)
-4. **Collab CRDT**: 7-10 天 (⭐⭐⭐ 高)
+1. **Monorepo Foundation** (Branch 1): ✅ 已完成
+2. **Renderer 统一** (Branch 1.5): 3-4 天 (⭐⭐ 中) ← **建议下一步**
+3. **Iframe Preview** (Branch 2): 3-4 天 (⭐⭐⭐ 高，依赖 1.5)
+4. **CodeGen Decoupling** (Branch 3): 2-3 天 (⭐ 低)
+5. **Collab CRDT** (Branch 4): 7-10 天 (⭐⭐⭐ 高)

--- a/packages/editor/src/config/featureFlags.ts
+++ b/packages/editor/src/config/featureFlags.ts
@@ -1,0 +1,47 @@
+/**
+ * @file 特性开关 (Feature Flags)
+ * @description
+ * 控制实验性/渐进式功能的启用。
+ * 当新功能稳定后（通常 1 个迭代），移除对应开关及旧路径代码。
+ *
+ * 读取优先级：
+ * 1. URL 参数 (方便 QA 切换): `?ff.unifiedRenderer=false`
+ * 2. localStorage: `ff.unifiedRenderer`
+ * 3. 默认值
+ *
+ * @module Config/FeatureFlags
+ */
+
+function readFlag(key: string, defaultValue: boolean): boolean {
+  // 1. URL 参数
+  if (typeof window !== "undefined") {
+    const params = new URLSearchParams(window.location.search);
+    const urlVal = params.get(`ff.${key}`);
+    if (urlVal === "true") return true;
+    if (urlVal === "false") return false;
+
+    // 2. localStorage
+    try {
+      const stored = localStorage.getItem(`ff.${key}`);
+      if (stored === "true") return true;
+      if (stored === "false") return false;
+    } catch {
+      // localStorage 不可用（iframe sandbox 等）
+    }
+  }
+
+  // 3. 默认值
+  return defaultValue;
+}
+
+/**
+ * 是否使用统一渲染引擎 SchemaRenderer（@lowcode/renderer）。
+ *
+ * - `true`（默认）: 使用新的 SchemaRenderer 渲染路径
+ * - `false`: 回退到旧的内联 RenderNode 渲染路径
+ *
+ * 切换方式：
+ * - URL: `?ff.unifiedRenderer=false`
+ * - 控制台: `localStorage.setItem('ff.unifiedRenderer', 'false')` 然后刷新
+ */
+export const UNIFIED_RENDERER = readFlag("unifiedRenderer", true);

--- a/packages/editor/src/editor/hooks/useEventOrchestrator.ts
+++ b/packages/editor/src/editor/hooks/useEventOrchestrator.ts
@@ -1,0 +1,120 @@
+/**
+ * @file useEventOrchestrator — 运行态事件编排 Hook
+ * @description
+ * 从旧 Preview 组件提取的事件编排逻辑，
+ * 封装为独立 Hook 供 SchemaRenderer(designMode="live") 的 onEvent 回调使用。
+ *
+ * 支持的动作类型：
+ * - goToLink     — 跳转链接
+ * - showMessage  — 消息提示
+ * - customJs     — iframe 沙盒执行用户代码
+ * - componentMethod — 调用目标组件方法
+ *
+ * 设计原则：
+ * - 事件编排保留在 editor 包（不下沉到 renderer 包）
+ * - executeSandboxedCode 直接在此使用（editor 内部模块）
+ * - 通过 onEvent 签名与 SchemaRenderer 解耦
+ *
+ * @module Editor/Hooks/useEventOrchestrator
+ */
+
+import { useCallback, useRef } from "react";
+import { message } from "antd";
+import type { ComponentConfig } from "@lowcode/materials";
+import type { Component } from "@lowcode/schema";
+import type { EventHandler } from "@lowcode/renderer";
+import type { ActionConfig } from "../components/Setting/ComponentEvent/ActionModal";
+import { executeSandboxedCode } from "../utils/sandboxExecutor";
+
+export interface UseEventOrchestratorOptions {
+  /** 组件 Map（id → Component） */
+  components: Record<number, Component>;
+  /** 物料配置 Map（name → ComponentConfig） */
+  componentConfig: Record<string, ComponentConfig>;
+}
+
+export interface EventOrchestratorResult {
+  /** 作为 SchemaRenderer 的 onEvent prop */
+  handleEvent: EventHandler;
+  /** 作为 SchemaRenderer 的 onCompRef prop，收集组件实例 */
+  handleCompRef: (componentId: number, ref: unknown) => void;
+}
+
+/**
+ * 运行态事件编排 Hook
+ *
+ * @example
+ * ```tsx
+ * const { handleEvent, handleCompRef } = useEventOrchestrator({
+ *   components, componentConfig,
+ * });
+ * <SchemaRenderer designMode="live" onEvent={handleEvent} onCompRef={handleCompRef} />
+ * ```
+ */
+export function useEventOrchestrator({
+  components,
+  componentConfig,
+}: UseEventOrchestratorOptions): EventOrchestratorResult {
+  /**
+   * 存储所有渲染出来的组件实例引用。
+   * key 为组件 ID，value 为组件实例。
+   * 用于实现 "componentMethod" 类型的动作。
+   */
+  const componentRefs = useRef<Record<string, unknown>>({});
+
+  const handleCompRef = useCallback((componentId: number, ref: unknown) => {
+    componentRefs.current[componentId] = ref;
+  }, []);
+
+  const handleEvent: EventHandler = useCallback(
+    (componentId: number, eventName: string, args: unknown[]) => {
+      const component = components[componentId];
+      if (!component) return;
+
+      const config = componentConfig[component.name];
+      if (!config) return;
+
+      const eventConfig = component.props[eventName] as
+        | { actions?: ActionConfig[] }
+        | undefined;
+
+      if (!eventConfig?.actions) return;
+
+      for (const action of eventConfig.actions) {
+        if (action.type === "goToLink") {
+          window.location.href = action.url;
+        } else if (action.type === "showMessage") {
+          if (action.config.type === "success") {
+            message.success(action.config.text);
+          } else if (action.config.type === "error") {
+            message.error(action.config.text);
+          }
+        } else if (action.type === "customJs") {
+          executeSandboxedCode(action.code, {
+            name: component.name,
+            props: component.props,
+            onShowMessage: (content: string) => message.success(content),
+            eventArgs: args,
+          }).catch((err: Error) => {
+            message.error(`自定义代码执行失败: ${err.message}`);
+          });
+        } else if (action.type === "componentMethod") {
+          const target = componentRefs.current[
+            action.config.componentId
+          ] as Record<string, (...a: unknown[]) => void> | undefined;
+          if (target) {
+            if (action.config.args) {
+              const params = Object.values(action.config.args);
+              target[action.config.method]?.(...params);
+            } else {
+              target[action.config.method]?.();
+            }
+          }
+        }
+      }
+    },
+    [components, componentConfig],
+  );
+
+  return { handleEvent, handleCompRef };
+}

--- a/packages/renderer/src/SchemaRenderer.tsx
+++ b/packages/renderer/src/SchemaRenderer.tsx
@@ -1,0 +1,227 @@
+/**
+ * @file SchemaRenderer — 统一渲染核心
+ * @description
+ * 负责将范式化的 components Map 递归渲染为 React 组件树。
+ * 同一组件通过 designMode 服务 design（编辑态）和 live（运行态）两种场景。
+ *
+ * 设计原则（参考阿里 lowcode-engine）：
+ * 1. 纯渲染管道 — 不依赖任何 store / editor 模块
+ * 2. 设计态能力通过 designHooks 注入（customCreateElement / onCompGetRef）
+ * 3. 运行态事件通过 onEvent 回调代理到上层（EventOrchestrator 在 editor 内）
+ *
+ * @module Renderer/SchemaRenderer
+ */
+
+import React, {
+  Suspense,
+  useMemo,
+  createContext,
+  useContext,
+  type ReactElement,
+} from "react";
+import type { Component } from "@lowcode/schema";
+import type { ComponentConfig } from "@lowcode/materials";
+import type {
+  SchemaRendererProps,
+  DesignHooks,
+  EventHandler,
+  RenderNodeProps,
+} from "./types";
+
+// ==================== Context ====================
+
+/**
+ * 渲染上下文 — 通过 Context 避免逐层 props drilling
+ */
+interface RendererContextValue {
+  components: Record<number, Component>;
+  componentMap: Record<string, ComponentConfig>;
+  designMode: "design" | "live";
+  designHooks: DesignHooks;
+  onEvent?: EventHandler;
+  onCompRef?: (componentId: number, ref: unknown) => void;
+  suspenseFallback: ReactElement;
+}
+
+const RendererContext = createContext<RendererContextValue | null>(null);
+
+function useRendererContext(): RendererContextValue {
+  const ctx = useContext(RendererContext);
+  if (!ctx) {
+    throw new Error(
+      "[SchemaRenderer] RenderNode must be used inside <SchemaRenderer>",
+    );
+  }
+  return ctx;
+}
+
+// ==================== RenderNode ====================
+
+/**
+ * 递归渲染单节点。
+ * 从 RendererContext 获取 components / componentMap / hooks 等信息，
+ * 根据 designMode 走不同分支。
+ */
+const RenderNode: React.FC<RenderNodeProps> = React.memo(({ id }) => {
+  const {
+    components,
+    componentMap,
+    designMode,
+    designHooks,
+    onEvent,
+    onCompRef,
+    suspenseFallback,
+  } = useRendererContext();
+
+  const component = components[id];
+  if (!component) return null;
+
+  const config = componentMap[component.name];
+  if (!config) return null;
+
+  // ---- 选择组件实现 ----
+  // 设计态使用 component（编辑器形态），运行态优先 runtimeComponent（如 Modal 弹窗形态）
+  const ComponentImpl =
+    designMode === "live"
+      ? config.runtimeComponent || config.component
+      : config.component;
+
+  if (!ComponentImpl) return null;
+
+  // ---- 合并 props ----
+  const mergedProps: Record<string, unknown> = {
+    ...config.defaultProps,
+    ...component.props,
+    style: component.styles,
+  };
+
+  // ---- 设计态：注入 data-component-id 用于蒙层定位 ----
+  if (designMode === "design") {
+    mergedProps["data-component-id"] = component.id;
+  }
+
+  // ---- 运行态：绑定事件 ----
+  if (designMode === "live" && onEvent && config.events) {
+    for (const event of config.events) {
+      const eventConfig = component.props[event.name] as
+        | { actions?: unknown[] }
+        | undefined;
+      if (eventConfig?.actions?.length) {
+        mergedProps[event.name] = (...args: unknown[]) => {
+          onEvent(component.id, event.name, args);
+        };
+      }
+    }
+  }
+
+  // ---- 运行态：收集组件 ref ----
+  if (designMode === "live" && onCompRef) {
+    mergedProps.ref = (ref: unknown) => {
+      onCompRef(component.id, ref);
+    };
+  }
+
+  // ---- 递归子节点 ----
+  const childElements = component.children?.map((childId) => (
+    <RenderNode key={childId} id={childId} />
+  ));
+
+  // ---- createElement ----
+  const element = React.createElement(
+    ComponentImpl,
+    mergedProps,
+    childElements,
+  );
+
+  // ---- 设计态：customCreateElement 包装（注入 DragWrapper 等） ----
+  const wrappedElement =
+    designMode === "design" && designHooks.customCreateElement
+      ? designHooks.customCreateElement(component.id, component.name, element)
+      : element;
+
+  return <Suspense fallback={suspenseFallback}>{wrappedElement}</Suspense>;
+});
+
+RenderNode.displayName = "RenderNode";
+
+// ==================== SchemaRenderer ====================
+
+const DEFAULT_FALLBACK = (
+  <div style={{ padding: 8, color: "#999" }}>Loading...</div>
+);
+const EMPTY_HOOKS: DesignHooks = {};
+
+/**
+ * SchemaRenderer — 核心渲染入口
+ *
+ * @example 设计态 (editor iframe 内)
+ * ```tsx
+ * <SchemaRenderer
+ *   components={components}
+ *   rootId={rootId}
+ *   componentMap={componentConfigMap}
+ *   designMode="design"
+ *   designHooks={{
+ *     customCreateElement: (id, name, el) => <DragWrapper id={id}>{el}</DragWrapper>,
+ *     onCompGetRef: (id, el) => collect(id, el),
+ *   }}
+ * />
+ * ```
+ *
+ * @example 运行态 (预览模式)
+ * ```tsx
+ * <SchemaRenderer
+ *   components={components}
+ *   rootId={rootId}
+ *   componentMap={componentConfig}
+ *   designMode="live"
+ *   onEvent={handleEvent}
+ *   onCompRef={(id, ref) => { refs.current[id] = ref; }}
+ * />
+ * ```
+ */
+export const SchemaRenderer: React.FC<SchemaRendererProps> = React.memo(
+  ({
+    components,
+    rootId,
+    componentMap,
+    designMode = "live",
+    designHooks = EMPTY_HOOKS,
+    onEvent,
+    onCompRef,
+    suspenseFallback = DEFAULT_FALLBACK,
+  }) => {
+    const contextValue = useMemo<RendererContextValue>(
+      () => ({
+        components,
+        componentMap,
+        designMode,
+        designHooks,
+        onEvent,
+        onCompRef,
+        suspenseFallback,
+      }),
+      [
+        components,
+        componentMap,
+        designMode,
+        designHooks,
+        onEvent,
+        onCompRef,
+        suspenseFallback,
+      ],
+    );
+
+    if (!rootId || !components[rootId]) {
+      return null;
+    }
+
+    return (
+      <RendererContext.Provider value={contextValue}>
+        <RenderNode id={rootId} />
+      </RendererContext.Provider>
+    );
+  },
+);
+
+SchemaRenderer.displayName = "SchemaRenderer";

--- a/packages/renderer/src/index.tsx
+++ b/packages/renderer/src/index.tsx
@@ -1,43 +1,22 @@
- 
-import React, { Suspense } from "react";
-import type { Component, ComponentProtocol } from "@lowcode/schema";
-import { materials } from "@lowcode/materials";
+/**
+ * @file @lowcode/renderer 入口
+ * @description
+ * 统一渲染引擎包 — 提供 SchemaRenderer 组件与类型导出。
+ *
+ * SchemaRenderer 是唯一的组件树渲染核心，通过 designMode 同时服务
+ * 设计态（编辑画布 / iframe）和运行态（预览模式）。
+ *
+ * @module Renderer
+ */
 
-interface RendererProps {
-  component: Component;
-}
+// ---- 核心组件 ----
+export { SchemaRenderer } from "./SchemaRenderer";
 
-const materialMap = new Map<string, ComponentProtocol>(
-  materials.map((m) => [m.name, m]),
-);
+// ---- 类型导出 ----
+export type {
+  SchemaRendererProps,
+  DesignHooks,
+  EventHandler,
+  RenderNodeProps,
+} from "./types";
 
-export const Renderer: React.FC<RendererProps> = ({ component }) => {
-  const { name, props, children, id } = component;
-  const material = materialMap.get(name);
-
-  if (!material) {
-    return <div>Component {name} not found</div>;
-  }
-
-  const ComponentToRender = material.runtimeComponent || material.component;
-
-  // 递归渲染子组件
-  // 注意：这里假设 children 是 Component[]，实际项目中可能是 id[] 需要结合 store 获取
-  // 为了从简，这里先假设 component 结构体已经包含了完整的 children 树，或者我们在上层做了转换
-  // 在当前 store 设计中，children 是 number[]，所以 Renderer 需要配合 Store 使用
-  // 但为了解耦，Renderer 最好只接受标准 Tree 结构
-
-  // 临时：如果 children 是 id 数组，这里无法渲染，需要上层转换。
-  // 我们先假设传入的 component 是已经转换好的树状结构 ComponentTree (在 schema/component.ts 中定义)
-
-  return (
-    <Suspense fallback={<div>Loading...</div>}>
-      <ComponentToRender {...props} id={id}>
-        {Array.isArray(children) &&
-          children.map((child: any) => (
-            <Renderer key={child.id} component={child} />
-          ))}
-      </ComponentToRender>
-    </Suspense>
-  );
-};

--- a/packages/renderer/src/types.ts
+++ b/packages/renderer/src/types.ts
@@ -1,0 +1,122 @@
+/**
+ * @file @lowcode/renderer 类型定义
+ * @description
+ * 统一渲染引擎的输入契约（Step 1.5.0）。
+ * 输入模型冻结为：components + rootId + componentMap（范式化 Map），
+ * 不混用树结构输入。
+ *
+ * @module Renderer/Types
+ */
+
+import type { ReactElement } from "react";
+import type { Component } from "@lowcode/schema";
+import type { ComponentConfig } from "@lowcode/materials";
+
+// ==================== 设计态注入点 ====================
+
+/**
+ * 设计态钩子 — 由 editor 侧注入，renderer 只定义接口
+ *
+ * 参考阿里 lowcode-engine：
+ * - customCreateElement → 包裹 DragWrapper / 注入 data-component-id
+ * - onCompGetRef → 收集 DOM 实例用于蒙层定位
+ */
+export interface DesignHooks {
+  /**
+   * 组件 DOM 挂载/更新时回调。
+   * editor 侧用此回调收集每个节点的 DOM 实例，
+   * 用于计算 HoverMask / SelectedMask 位置。
+   */
+  onCompGetRef?: (componentId: number, el: HTMLElement | null) => void;
+
+  /**
+   * 自定义 createElement 包装器。
+   * editor 侧通过此钩子注入 DragWrapper、data-component-id 等设计态能力。
+   *
+   * @param componentId  当前渲染的组件 ID
+   * @param componentName 当前渲染的组件名称
+   * @param element      SchemaRenderer 构造好的原始 ReactElement
+   * @returns            包装后的 ReactElement
+   */
+  customCreateElement?: (
+    componentId: number,
+    componentName: string,
+    element: ReactElement,
+  ) => ReactElement;
+}
+
+// ==================== 事件回调 ====================
+
+/**
+ * 运行态事件回调签名。
+ * 由 editor 侧的 EventOrchestrator 实现（goToLink / showMessage / customJs / componentMethod）。
+ * renderer 本身不包含事件编排逻辑。
+ */
+export type EventHandler = (
+  componentId: number,
+  eventName: string,
+  args: unknown[],
+) => void;
+
+// ==================== 核心 Props ====================
+
+/**
+ * SchemaRenderer 的完整 Props — 渲染引擎输入契约
+ *
+ * 设计原则：
+ * - designMode 切换行为，不切换数据模型
+ * - renderer 包 **不依赖** 任何 store / editor 模块
+ * - 设计态能力通过 designHooks 注入，运行态事件通过 onEvent 注入
+ */
+export interface SchemaRendererProps {
+  /** 范式化的组件 Map（id → Component） */
+  components: Record<number, Component>;
+
+  /** 根节点 ID */
+  rootId: number;
+
+  /** 物料注册表 — name → ComponentConfig 的映射 */
+  componentMap: Record<string, ComponentConfig>;
+
+  /**
+   * 渲染模式
+   * - `"design"` — 设计态，注入 data-component-id、收集 ref、使用 component
+   * - `"live"`   — 运行态，绑定事件编排、优先使用 runtimeComponent
+   *
+   * @default "live"
+   */
+  designMode?: "design" | "live";
+
+  /**
+   * 设计态钩子（仅 designMode="design" 时生效）。
+   * 由 editor 侧注入，renderer 不实现任何编辑器逻辑。
+   */
+  designHooks?: DesignHooks;
+
+  /**
+   * 运行态事件回调（仅 designMode="live" 时生效）。
+   * 组件触发事件时，SchemaRenderer 调用此回调将事件代理到上层。
+   */
+  onEvent?: EventHandler;
+
+  /**
+   * 运行态组件 ref 回调（仅 designMode="live" 时生效）。
+   * 用于收集组件实例（componentMethod 场景下需要调用组件方法）。
+   */
+  onCompRef?: (componentId: number, ref: unknown) => void;
+
+  /**
+   * 懒加载的 fallback 组件
+   * @default <div style={{ padding: 8, color: '#999' }}>Loading...</div>
+   */
+  suspenseFallback?: ReactElement;
+}
+
+// ==================== 内部辅助 ====================
+
+/**
+ * 单节点渲染 Props（SchemaRenderer 内部使用）
+ */
+export interface RenderNodeProps {
+  id: number;
+}


### PR DESCRIPTION
- Step 1.5.0: Freeze input contract (types.ts: SchemaRendererProps, DesignHooks)
- Step 1.5.1: Implement SchemaRenderer with Context + RenderNode
- Step 1.5.2: Define capability boundaries (editor owns DragWrapper/Masks/Events)
- Step 1.5.3: Replace RendererEditArea to use SchemaRenderer(design)
- Step 1.5.4: Replace Preview to use SchemaRenderer(live) + useEventOrchestrator
- Step 1.5.5: Add feature flag (ff.unifiedRenderer) with legacy fallback paths

Design principles (Ali lowcode-engine inspired):
- Pure rendering pipeline — no store/editor dependency in renderer
- Design-mode capabilities injected via designHooks (customCreateElement)
- Event orchestration stays in editor package (useEventOrchestrator hook)
- Feature flag supports URL param and localStorage toggling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a feature flag system allowing control of rendering behavior via URL parameters or localStorage (default: unified renderer enabled).

* **Refactor**
  * Unified rendering architecture with design and live mode support.
  * Enhanced event orchestration system for improved runtime event handling.
  * Consolidated renderer pipeline for better maintainability and extensibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->